### PR TITLE
Update master.tf

### DIFF
--- a/data/data/azure/master/master.tf
+++ b/data/data/azure/master/master.tf
@@ -104,7 +104,7 @@ resource "azurerm_linux_virtual_machine" "master" {
 
   os_disk {
     name                 = "${var.cluster_id}-master-${count.index}_OSDisk" # os disk name needs to match cluster-api convention
-    caching              = "ReadOnly"
+    caching              = "None"
     storage_account_type = var.os_volume_type
     disk_size_gb         = var.os_volume_size
   }


### PR DESCRIPTION
update os caching to 'None'

We set “Host Caching” to Read-Only on master nodes(Standard_D8s_v3) for better IOPS and low latency,  here we can find some discussion[1], however, we met a throttling event a few days ago, this event cause ‘etcdHighNumberOfLeaderChanges’ issue, when this alerting was fired the throughput was around 140 MB/s and IOPS is around 1000, but the max cached is 128 MB/s on this type of VM,  so it was throttled by Azure, according to Azure’s recommendations, they say it might be changed Host Caching to ‘None’, throughput will increase to 192 MB/s, but the IOPS will drop from 16000 to 12800.

[1] https://github.com/openshift/installer/pull/2186
[2] https://docs.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series